### PR TITLE
Display reviews as cards with modal expansion

### DIFF
--- a/app/assets/stylesheets/forgotten.css
+++ b/app/assets/stylesheets/forgotten.css
@@ -267,12 +267,8 @@ label{ color: var(--muted) }
   margin: 14px 0;
 }
 
-.reviews { list-style: none; margin: 0; padding: 0 }
-.review { margin: 10px 0 14px; padding: 0 }
-.review-head { margin-bottom: 6px }
 .review-body { margin: 0 0 8px }
 
-.review-actions { margin-top: 4px }
 .btn--sm { padding: 6px 10px; font-size: 13px }
 
 /* form tweaks reused from earlier forms pack */
@@ -313,7 +309,7 @@ label{ color: var(--muted) }
 html { scroll-behavior: smooth; }
 
 /* briefly highlight the anchored review */
-.review:target {
+.review-card:target {
   outline: 2px solid var(--gold);
   outline-offset: 4px;
   background: rgba(202,163,82,.08);
@@ -337,3 +333,28 @@ html { scroll-behavior: smooth; }
 .book-actions .btn:hover {
   background-color: #a1632e;
 }
+
+.review-grid{
+  display:grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px; margin-top: 10px;
+}
+.review-card{
+  background: var(--panel);
+  border: 1px solid var(--gold-deep);
+  border-radius: 6px;
+  padding: 12px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
+}
+.review-card h3{ margin:0 0 6px }
+.review-card h3 a{ color: var(--ink); text-decoration:none; border-bottom: 1px dotted var(--gold); padding-bottom: 2px; }
+.review-card h3 a:hover{ color: var(--gold) }
+.review-card .rating{ color: var(--gold); margin:0 0 8px }
+.review-card .date{ color: var(--muted); margin-top:8px }
+.review-card .like-section{ display:flex; align-items:center; gap:8px; margin-top:8px }
+.review-card .like-section form{ margin:0 }
+.review-card .like-count{ color: var(--muted) }
+
+.modal{ display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); align-items:center; justify-content:center; padding:20px; }
+.modal.open{ display:flex }
+.modal-content{ background:var(--panel); border:1px solid var(--gold-deep); border-radius:6px; padding:20px; max-width:500px; max-height:80%; overflow:auto; }
+.modal-close{ background:none; border:none; float:right; font-size:16px; cursor:pointer; color:var(--ink); }

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -12,7 +12,7 @@ class BooksController < ApplicationController
 
   def show
     @book = Book.find(params[:id])
-    @reviews = @book.reviews.includes(:user).order(created_at: :desc)
+    @reviews = @book.reviews.includes(:user, :review_likes).order(created_at: :desc)
     @review  = Review.new
   end
 

--- a/app/controllers/review_likes_controller.rb
+++ b/app/controllers/review_likes_controller.rb
@@ -1,0 +1,17 @@
+class ReviewLikesController < ApplicationController
+  before_action :require_login
+
+  def create
+    review = Review.find(params[:review_id])
+    return redirect_back fallback_location: review.book, alert: "Not authorized" if review.user == current_user
+
+    review.review_likes.find_or_create_by(user: current_user)
+    redirect_back fallback_location: review.book
+  end
+
+  def destroy
+    review = Review.find(params[:review_id])
+    review.review_likes.where(user: current_user).destroy_all
+    redirect_back fallback_location: review.book
+  end
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -3,7 +3,7 @@ class ReviewsController < ApplicationController
 
   def index
     @reviews = current_user.reviews
-                           .includes(:book)
+                           .includes(:book, :review_likes)
                            .order(created_at: :desc)
   end
 
@@ -13,7 +13,7 @@ class ReviewsController < ApplicationController
     if @review.save
       redirect_to @book, notice: "Review posted."
     else
-      @reviews = @book.reviews.includes(:user).order(created_at: :desc)
+      @reviews = @book.reviews.includes(:user, :review_likes).order(created_at: :desc)
       render "books/show", status: :unprocessable_entity
     end
   end

--- a/app/javascript/controllers/review_modal_controller.js
+++ b/app/javascript/controllers/review_modal_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal"]
+
+  open(event) {
+    event.preventDefault()
+    this.modalTarget.classList.add("open")
+  }
+
+  close(event) {
+    event.preventDefault()
+    this.modalTarget.classList.remove("open")
+  }
+}

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,6 +1,16 @@
 class Review < ApplicationRecord
   belongs_to :book
   belongs_to :user
+  has_many :review_likes, dependent: :destroy
+
   validates :rating, inclusion: { in: 1..5 }
   validates :body, presence: true
+
+  before_save :strip_html_from_body
+
+  private
+
+  def strip_html_from_body
+    self.body = ActionController::Base.helpers.sanitize(body, tags: [], attributes: [])
+  end
 end

--- a/app/models/review_like.rb
+++ b/app/models/review_like.rb
@@ -1,0 +1,13 @@
+class ReviewLike < ApplicationRecord
+  belongs_to :review, counter_cache: true
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :review_id }
+  validate :author_cannot_like_own_review
+
+  private
+
+  def author_cannot_like_own_review
+    errors.add(:user_id, "can't like your own review") if review.user_id == user_id
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,11 @@ class User < ApplicationRecord
   has_many :library_entries, dependent: :destroy
   has_many :books, through: :library_entries
   has_many :reviews, dependent: :destroy
+  has_many :review_likes, dependent: :destroy
+  has_many :liked_reviews, through: :review_likes, source: :review
 
   validates :password, length: { minimum: 6 }, if: -> { password.present? }
-  validates :name,  presence: true
+  validates :name,  presence: true,
+                    format: { with: /\A[^0-9]*\z/, message: "cannot contain numbers" }
   validates :email, presence: true, uniqueness: true
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,25 +10,11 @@
 
   <h3>Reviews</h3>
   <% if @reviews.any? %>
-    <ul class="reviews">
-      <% @reviews.each do |rev| %>
-        <li class="review" id="review-<%= rev.id %>">
-          <div class="review-head">
-            <strong><%= rev.user.name %></strong> – <%= rev.rating %>/5
-          </div>
-          <div class="review-body"><%= simple_format(rev.body) %></div>
-          <% if logged_in? && rev.user == current_user %>
-            <div class="review-actions">
-              <%= button_to "Delete",
-                    book_review_path(@book, rev),
-                    method: :delete,
-                    data: { turbo_confirm: "Delete this review?" },
-                    class: "btn btn--danger btn--sm" %>
-            </div>
-          <% end %>
-        </li>
+    <div class="review-grid">
+      <% @reviews.each do |review| %>
+        <%= render "reviews/review_card", review: review, show_book: false %>
       <% end %>
-    </ul>
+    </div>
   <% else %>
     <p class="muted">No reviews yet.</p>
   <% end %>

--- a/app/views/reviews/_review_card.html.erb
+++ b/app/views/reviews/_review_card.html.erb
@@ -1,0 +1,43 @@
+<% show_book = local_assigns.fetch(:show_book, true) %>
+<% sanitized_body = sanitize(review.body, tags: []) %>
+<div class="review-card" data-controller="review-modal" id="review-<%= review.id %>">
+  <% if show_book %>
+    <h3><%= link_to review.book.title, review.book %></h3>
+  <% else %>
+    <h3><%= review.user.name %></h3>
+  <% end %>
+  <p class="rating"><strong><%= review.rating %></strong> / 5</p>
+  <p class="review-body">
+    <% if sanitized_body.length > 150 %>
+      <%= truncate(sanitized_body, length: 150) %>
+    <% else %>
+      <%= sanitized_body %>
+    <% end %>
+  </p>
+  <% if sanitized_body.length > 150 %>
+    <button class="btn btn--sm see-more-btn" data-action="review-modal#open">See more</button>
+    <div class="modal" data-review-modal-target="modal">
+      <div class="modal-content">
+        <button class="modal-close" data-action="review-modal#close">Close</button>
+        <p><%= simple_format(sanitized_body) %></p>
+      </div>
+    </div>
+  <% end %>
+  <div class="like-section">
+    <span class="like-count"><%= pluralize(review.review_likes.size, 'like') %></span>
+    <% if logged_in? && review.user != current_user %>
+      <% if review.review_likes.exists?(user: current_user) %>
+        <%= button_to 'Unlike', review_like_path(review), method: :delete, class: 'btn btn--sm' %>
+      <% else %>
+        <%= button_to 'Like', review_like_path(review), method: :post, class: 'btn btn--sm' %>
+      <% end %>
+    <% end %>
+  </div>
+  <p class="date"><%= review.created_at.strftime("%b %d, %Y") %></p>
+  <% if review.user == current_user %>
+    <%= button_to "Delete", book_review_path(review.book, review),
+          method: :delete,
+          data: { turbo_confirm: "Delete this review?" },
+          class: "btn btn--danger btn--sm" %>
+  <% end %>
+</div>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -9,41 +9,9 @@
 <% if @reviews.empty? %>
   <p>You haven’t posted any reviews yet.</p>
 <% else %>
-    <table class="reviews-table">
-    <thead>
-        <tr>
-        <th>Book</th>
-        <th>Rating</th>
-        <th>Review</th>
-        <th>Date</th>
-        <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        <% @reviews.each do |review| %>
-        <tr>
-            <td><%= link_to review.book.title, review.book %></td>
-            <td><%= review.rating %>/5</td>
-            <td>
-            <% if review.body.length > 150 %>
-                <%= truncate(review.body, length: 150) %>
-                <%= link_to "Read more",
-                            book_path(review.book, anchor: "review-#{review.id}"),
-                            class: "read-more-link",
-                            data: { turbo: false } %>
-            <% else %>
-                <%= review.body %>
-            <% end %>
-            </td>
-            <td><%= review.created_at.strftime("%b %d, %Y") %></td>
-            <td>
-            <%= button_to "Delete", book_review_path(review.book, review),
-                    method: :delete,
-                    data: { turbo_confirm: "Delete this review?" },
-                    class: "btn btn--danger btn--sm" %>
-            </td>
-        </tr>
-        <% end %>
-    </tbody>
-    </table>
+  <div class="review-grid">
+    <% @reviews.each do |review| %>
+      <%= render "review_card", review: review %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -15,7 +15,7 @@
 
     <div class="field">
       <%= form.label :name, "Your name" %>
-      <%= form.text_field :name, placeholder: "First and last name" %>
+      <%= form.text_field :name, placeholder: "First and last name", pattern: "[A-Za-z\\s]+" %>
     </div>
 
     <div class="field">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
 
   get "my/reviews", to: "reviews#index", as: :my_reviews
 
+  resources :reviews, only: [] do
+    resource :like, only: [ :create, :destroy ], controller: "review_likes"
+  end
+
   resources :library_entries, only: [ :index ] do
     member { patch :toggle_status }                     # read <-> not_read_yet
   end

--- a/db/migrate/20250809090000_create_review_likes.rb
+++ b/db/migrate/20250809090000_create_review_likes.rb
@@ -1,0 +1,12 @@
+class CreateReviewLikes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :review_likes do |t|
+      t.references :review, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :review_likes, [:review_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20250809090100_add_review_likes_count_to_reviews.rb
+++ b/db/migrate/20250809090100_add_review_likes_count_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddReviewLikesCountToReviews < ActiveRecord::Migration[8.0]
+  def change
+    add_column :reviews, :review_likes_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_09_073514) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_09_090100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -44,8 +44,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_09_073514) do
     t.bigint "book_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "review_likes_count", default: 0, null: false
     t.index ["book_id"], name: "index_reviews_on_book_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
+  end
+
+  create_table "review_likes", force: :cascade do |t|
+    t.bigint "review_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id", "user_id"], name: "index_review_likes_on_review_id_and_user_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -60,4 +69,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_09_073514) do
   add_foreign_key "library_entries", "users"
   add_foreign_key "reviews", "books"
   add_foreign_key "reviews", "users"
+  add_foreign_key "review_likes", "reviews"
+  add_foreign_key "review_likes", "users"
 end


### PR DESCRIPTION
## Summary
- Show "My Reviews" and book reviews as responsive grids of review cards
- Add Stimulus controller and modal markup so long reviews can expand
- Style review cards and modal overlay in the site theme
- Use descriptive variable naming for review iteration on the book page
- Allow liking others' reviews and display like counts
- Sanitize review bodies and disallow digits in account names

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bin/rails test` *(fails: Could not find rails-8.0.2, propshaft-1.2.1, pg-1.6.1-x86_64-linux, pg-1.6.1, puma-6.6.1, importmap-rails-2.2.2, turbo-rails-2.0.16, stimulus-rails-1.3.4, jbuilder-2.13.0, solid_cache-1.0.7, solid_queue-1.2.1, solid_cable-3.0.11, bootsnap-1.18.6, kamal-2.7.0, thruster-0.1.15-x86_64-linux, thruster-0.1.15, debug-1.11.0, brakeman-7.1.0, rubocop-rails-omakase-1.1.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.34.0, bcrypt-3.1.20, csv-3.3.5, actioncable-8.0.2, actionmailbox-8.0.2, actionmailer-8.0.2, actionpack-8.0.2, actiontext-8.0.2, actionview-8.0.2, activejob-8.0.2, activemodel-8.0.2, activerecord-8.0.2, activestorage-8.0.2, activesupport-8.0.2, railties-8.0.2, rack-3.2.0, nio4r-2.7.4, concurrent-ruby-1.3.5, fugit-1.11.1, thor-1.4.0, msgpack-1.8.0, base64-0.3.0, bcrypt_pbkdf-1.1.1, dotenv-3.1.8, ed25519-1.4.0, net-ssh-7.3.0, sshkit-1.24.0, zeitwerk-2.7.3, irb-1.15.2, reline-0.6.2, rubocop-1.79.2, rubocop-performance-1.25.0, rubocop-rails-2.32.0, bindex-0.8.1, addressable-2.8.7, matrix-0.4.3, mini_mime-1.1.5, nokogiri-1.18.9-x86_64-linux-gnu, rack-test-2.2.0, regexp_parser-2.11.0, xpath-3.2.0, logger-1.7.0, rexml-3.4.1, rubyzip-2.4.1, websocket-1.2.11, websocket-driver-0.8.0, mail-2.8.1, rails-dom-testing-2.3.0, rack-session-2.1.1, rails-html-sanitizer-1.6.2, useragent-0.16.11, globalid-1.2.1, builder-3.3.0, erubi-1.13.1, marcel-1.0.4, benchmark-0.4.1, bigdecimal-3.2.2, connection_pool-2.5.3, drb-2.2.3, i18n-1.14.7, minitest-5.25.5, tzinfo-2.0.6, rackup-2.2.1, rake-13.3.0, et-orbi-1.3.0, raabro-1.4.0, net-scp-4.1.0, net-sftp-4.0.0, ostruct-0.6.3, rdoc-6.14.2, io-console-0.8.1, json-2.13.2, language_server-protocol-3.17.0.5, lint_roller-1.1.0, parallel-1.27.0, parser-3.3.9.0, rainbow-3.1.1, rubocop-ast-1.46.0, ruby-progressbar-1.13.0, unicode-display_width-3.1.4, public_suffix-6.0.2, websocket-extensions-0.1.5, net-imap-0.5.9, loofah-2.24.1, erb-5.0.2, psych-5.2.6, ast-2.4.3, prism-1.4.0, unicode-emoji-4.0.4, crass-1.0.6, stringio-3.1.7 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_689808183ef08321bf66a8fb33b8512d