### PR TITLE
Add mobile navigation menu and review pagination

### DIFF
--- a/app/assets/stylesheets/forgotten.css
+++ b/app/assets/stylesheets/forgotten.css
@@ -74,6 +74,16 @@ body{
 }
 .nav a:hover, .btn:hover{ filter: brightness(1.06) }
 
+.nav-toggle{
+  display:none;
+  background:none;
+  border:none;
+  font-size:24px;
+  color:var(--ink);
+  cursor:pointer;
+  margin-left:auto;
+}
+
 /* secondary pill button (back etc.) */
 .back-button{
   display:inline-block;
@@ -353,6 +363,14 @@ html { scroll-behavior: smooth; }
 .review-card .like-section{ display:flex; align-items:center; gap:8px; margin-top:8px }
 .review-card .like-section form{ margin:0 }
 .review-card .like-count{ color: var(--muted) }
+
+@media (max-width: 600px){
+  .header-inner{ flex-wrap:wrap; }
+  .nav{ display:none; flex-direction:column; gap:8px; width:100%; margin-top:8px; }
+  .nav.open{ display:flex; }
+  .nav-toggle{ display:block; }
+  .review-grid{ grid-template-columns:1fr; }
+}
 
 .modal{ display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); align-items:center; justify-content:center; padding:20px; }
 .modal.open{ display:flex }

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -12,7 +12,15 @@ class BooksController < ApplicationController
 
   def show
     @book = Book.find(params[:id])
-    @reviews = @book.reviews.includes(:user, :review_likes).order(created_at: :desc)
+    per_page = 5
+    @page = params[:page].to_i
+    offset = @page * per_page
+    @reviews = @book.reviews.includes(:user, :review_likes)
+                     .order(created_at: :desc)
+                     .offset(offset)
+                     .limit(per_page + 1)
+    @has_next = @reviews.size > per_page
+    @reviews = @reviews.first(per_page)
     @review  = Review.new
   end
 

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle() {
+    this.menuTarget.classList.toggle("open")
+  }
+}

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -15,6 +15,14 @@
         <%= render "reviews/review_card", review: review, show_book: false %>
       <% end %>
     </div>
+    <div class="review-pagination top-bar">
+      <% if @page.positive? %>
+        <%= link_to "Back", book_path(@book, page: @page - 1), class: "btn" %>
+      <% end %>
+      <% if @has_next %>
+        <%= link_to "Next", book_path(@book, page: @page + 1), class: "btn" %>
+      <% end %>
+    </div>
   <% else %>
     <p class="muted">No reviews yet.</p>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,10 @@
       <!-- banner + gold nav -->
       <div class="header">
         <div style="height:300px; background:url(<%= asset_path('banner.jpg') %>) center/cover no-repeat;"></div>
-        <div class="header-inner">
+        <div class="header-inner" data-controller="menu">
           <%= link_to raw('<span class="wordmark">Forgotten</span> Library'), root_path, class: "brand" %>
-          <nav class="nav">
+          <button class="nav-toggle" data-action="menu#toggle">&#9776;</button>
+          <nav class="nav" data-menu-target="menu">
             <%= link_to "Search", books_path %>
             <% if logged_in? %>
               <%= link_to "My Library", library_entries_path %>


### PR DESCRIPTION
## Summary
- Add Stimulus-powered hamburger menu that hides navigation links on small screens
- Stack review cards vertically on mobile devices and paginate book reviews with Next/Back controls

## Testing
- `bin/rails test` *(fails: could not find required gems; bundler reported 403 Forbidden while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6898686843288321ac25849dffa66d62