### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/assets/stylesheets/forgotten.css
+++ b/app/assets/stylesheets/forgotten.css
@@ -364,15 +364,43 @@ html { scroll-behavior: smooth; }
 .review-card .like-section form{ margin:0 }
 .review-card .like-count{ color: var(--muted) }
 
+/* Library cards for mobile view */
+.library-cards{ display:none; margin-top:10px; }
+.library-card{ background: var(--panel); border: 1px solid var(--gold-deep); border-radius: 6px; padding: 12px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); margin-bottom:10px; }
+.library-card h3{ margin:0 0 6px }
+.library-card .byline{ color: var(--muted); margin:0 0 8px }
+.library-card .actions{ display:flex; gap:8px }
+
 @media (max-width: 600px){
   .header-inner{ flex-wrap:wrap; }
   .nav{ display:none; flex-direction:column; gap:8px; width:100%; margin-top:8px; }
   .nav.open{ display:flex; }
   .nav-toggle{ display:block; }
   .review-grid{ grid-template-columns:1fr; }
+
+  /* search form stacks vertically */
+  .search-wrap form{ display:flex; flex-direction:column; gap:8px; }
+  .search-wrap input[type="text"],
+  .search-wrap input[type="search"],
+  .search-wrap .btn{ width:100%; max-width:100%; }
+
+  /* swap library table for cards */
+  .library-table{ display:none; }
+  .library-cards{ display:block; }
+
+  /* smaller headings */
+  h1{ font-size:1.4rem; }
+  .book-show h1{ font-size:1.3rem; }
+
+  /* form labels above inputs */
+  .form-panel .field{ grid-template-columns:1fr; }
+  .form-panel label{ margin-bottom:4px; }
+
+  /* modal fits screen */
+  .modal-content{ width:100%; max-width:100%; }
 }
 
 .modal{ display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); align-items:center; justify-content:center; padding:20px; }
 .modal.open{ display:flex }
-.modal-content{ background:var(--panel); border:1px solid var(--gold-deep); border-radius:6px; padding:20px; max-width:500px; max-height:80%; overflow:auto; }
+.modal-content{ background:var(--panel); border:1px solid var(--gold-deep); border-radius:6px; padding:20px; max-width:500px; max-height:80%; overflow:auto; box-sizing:border-box; }
 .modal-close{ background:none; border:none; float:right; font-size:16px; cursor:pointer; color:var(--ink); }

--- a/app/views/library_entries/index.html.erb
+++ b/app/views/library_entries/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 <h1>My Library</h1>
 <p>Signed in as <%= current_user.name %></p>
-<%# <%= button_to "Sign out", session_path, method: :delete %> 
+<%# <%= button_to "Sign out", session_path, method: :delete %>
 
 <p>
   Filter:
@@ -11,15 +11,14 @@
   <%= link_to "Read", library_entries_path(filter: "read") %> |
   <%= link_to "Not read yet", library_entries_path(filter: "not_read_yet") %>
 </p>
-
-<table>
-  <thead>
-    <tr><th>Title</th><th>Date Added</th><th>Status</th><th>Actions</th></tr>
-  </thead>
-  <tbody>
-    <% if @entries.empty? %>
-      <tr><td colspan="4" class="empty-row">No books yet.</td></tr>
-    <% else %>
+<% if @entries.empty? %>
+  <p class="empty-row">No books yet.</p>
+<% else %>
+  <table class="library-table">
+    <thead>
+      <tr><th>Title</th><th>Date Added</th><th>Status</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
       <% @entries.each do |entry| %>
         <tr>
           <td><%= link_to entry.book.title, book_path(entry.book) %></td>
@@ -37,6 +36,24 @@
           </td>
         </tr>
       <% end %>
+    </tbody>
+  </table>
+
+  <div class="library-cards">
+    <% @entries.each do |entry| %>
+      <div class="library-card">
+        <h3><%= link_to entry.book.title, book_path(entry.book) %></h3>
+        <p class="byline"><%= entry.date_added&.strftime("%B %d, %Y") %></p>
+        <div class="actions">
+          <%= button_to entry.status.humanize,
+                toggle_status_library_entry_path(entry),
+                method: :patch,
+                class: "status-button #{entry.status}" %>
+          <%= button_to "Remove",
+                remove_from_library_book_path(entry.book),
+                method: :delete, class: "btn" %>
+        </div>
+      </div>
     <% end %>
-  </tbody>
-</table>
+  </div>
+<% end %>


### PR DESCRIPTION
## Summary
- Switch library entries to card layout on small screens
- Fix search bar and review modal widths for mobile
- Reduce heading sizes and stack form labels on mobile devices

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689878e33b688321ab5aaab98e314a88