### PR TITLE
Replace browser confirms with modals

### DIFF
--- a/app/javascript/controllers/confirm_controller.js
+++ b/app/javascript/controllers/confirm_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal"]
+
+  open(event) {
+    event.preventDefault()
+    this.modalTarget.classList.add("open")
+  }
+
+  close(event) {
+    event.preventDefault()
+    this.modalTarget.classList.remove("open")
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,16 @@
               <%= link_to "My Library", library_entries_path %>
               <%= link_to "My Reviews", my_reviews_path %>
               <%= link_to "My Profile", profile_path %>
-              <%= link_to "Sign out", session_path, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+              <span data-controller="confirm">
+                <%= link_to "Sign out", "#", data: { action: "confirm#open" } %>
+                <div class="modal" data-confirm-target="modal">
+                  <div class="modal-content">
+                    <p>Are you sure?</p>
+                    <%= button_to "Sign out", session_path, method: :delete, class: "btn" %>
+                    <button type="button" class="btn" data-action="confirm#close">Cancel</button>
+                  </div>
+                </div>
+              </span>
             <% else %>
               <%= link_to "Sign in", new_session_path, class: "btn" %>
               <%= link_to "Create account", new_user_path, class: "btn" %>

--- a/app/views/reviews/_review_card.html.erb
+++ b/app/views/reviews/_review_card.html.erb
@@ -6,11 +6,15 @@
   <div class="review-header" style="display: flex; align-items: center;">
     <p class="date" style="margin: 0;"><%= review.created_at.strftime("%b %d, %Y") %></p>
     <% if review.user == current_user %>
-      <div style="margin-left: auto;">
-        <%= button_to "Delete", book_review_path(review.book, review),
-              method: :delete,
-              data: { turbo_confirm: "Delete this review?" },
-              class: "btn btn--danger btn--sm" %>
+      <div style="margin-left: auto;" data-controller="confirm">
+        <button type="button" class="btn btn--danger btn--sm" data-action="confirm#open">Delete</button>
+        <div class="modal" data-confirm-target="modal">
+          <div class="modal-content">
+            <p>Delete this review?</p>
+            <%= button_to "Delete", book_review_path(review.book, review), method: :delete, class: "btn btn--danger btn--sm" %>
+            <button type="button" class="btn btn--sm" data-action="confirm#close">Cancel</button>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Summary
- replace review deletion and sign-out confirmations with modals
- add Stimulus controller to handle modal open/close

## Testing
- `bundle exec rake test` *(fails: Could not find rails-8.0.2... in locally installed gems)*
- `bundle exec rubocop` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689c3b49b5f4832181cea844736dff4d