### PR TITLE
Improve reviews pagination with page numbers and results count

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -34,6 +34,10 @@ class BooksController < ApplicationController
                      .limit(per_page + 1)
     @has_next = @reviews.size > per_page
     @reviews = @reviews.first(per_page)
+    @reviews_count = @book.reviews.count
+    @total_pages = (@reviews_count.to_f / per_page).ceil
+    @results_start = offset + 1
+    @results_end = [offset + @reviews.size, @reviews_count].min
     if logged_in?
       @review = current_user.reviews.find_by(book: @book) || @book.reviews.new(user: current_user)
     else

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -79,12 +79,36 @@
         <%= render "reviews/review_card", review: review, show_book: false %>
       <% end %>
     </div>
+    <p class="muted">Results: <%= @results_start %> - <%= @results_end %> of <%= @reviews_count %></p>
     <div class="review-pagination top-bar">
       <% if @page.positive? %>
         <%= link_to "Back", book_path(@book, page: @page - 1) + "#reviews", class: "btn" %>
+      <% else %>
+        <span class="btn disabled">Back</span>
+      <% end %>
+      <% first_pages = [3, @total_pages].min %>
+      <% (0...first_pages).each do |p| %>
+        <% if p == @page %>
+          <span class="btn"><%= p + 1 %></span>
+        <% else %>
+          <%= link_to p + 1, book_path(@book, page: p) + "#reviews", class: "btn" %>
+        <% end %>
+      <% end %>
+      <% if @total_pages > 3 %>
+        <% if @total_pages > 4 %>
+          <span class="btn">&hellip;</span>
+        <% end %>
+        <% last_page = @total_pages - 1 %>
+        <% if last_page == @page %>
+          <span class="btn"><%= @total_pages %></span>
+        <% else %>
+          <%= link_to @total_pages, book_path(@book, page: last_page) + "#reviews", class: "btn" %>
+        <% end %>
       <% end %>
       <% if @has_next %>
         <%= link_to "Next", book_path(@book, page: @page + 1) + "#reviews", class: "btn" %>
+      <% else %>
+        <span class="btn disabled">Next</span>
       <% end %>
     </div>
   <% else %>


### PR DESCRIPTION
## Summary
- display conventional pagination for book reviews with page numbers and ellipsis
- show review result counts

## Testing
- `bundle exec rubocop app/controllers/books_controller.rb app/views/books/show.html.erb` *(fails: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rails test` *(fails: command not found)*
- `bundle exec rake test` *(fails: could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_689c756001d48321bd897f9f5ad11b88