### PR TITLE
Add modal-based review editing and hide duplicate book form

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -35,38 +35,16 @@
 
   <hr class="rule">
   <% if logged_in? %>
-    <h3><%= @review.persisted? ? "Edit your review" : "Write a review" %></h3>
-    <% if @review.errors[:rating].any? %>
-      <div class="alert">
-        <strong>Error:</strong> <%= @review.errors[:rating].first %>
-      </div>
-    <% end %>
-    <%= form_with model: [@book, @review], local: true, html: { class: "form-panel" } do |f| %>
-      <div class="field">
-        <%= f.label :rating %>
-        <div data-controller="rating">
-          <%= f.hidden_field :rating, value: @review.rating, data: { rating_target: "input" } %>
-          <div class="star-rating" data-rating-target="stars">
-            <% (1..5).each do |star| %>
-              <span
-                class="star"
-                data-action="click->rating#set mouseover->rating#hover mouseout->rating#resetHover"
-                data-rating-value="<%= star %>"
-              >★</span>
-            <% end %>
-          </div>
+    <% if @review.persisted? %>
+      <p>You have already reviewed this book.</p>
+    <% else %>
+      <h3>Write a review</h3>
+      <% if @review.errors[:rating].any? %>
+        <div class="alert">
+          <strong>Error:</strong> <%= @review.errors[:rating].first %>
         </div>
-      </div>
-
-      <div class="field field--full">
-        <%= f.label :body, "Your review (optional)" %>
-        <%= f.text_area :body, rows: 6, placeholder: "What did you think?" %>
-      </div>
-
-      <div class="actions">
-        <%= f.submit @review.persisted? ? "Update review" : "Post review" %>
-      </div>
-
+      <% end %>
+      <%= render "reviews/form", review: @review, book: @book %>
     <% end %>
   <% else %>
     <p class="muted"><%= link_to "Sign in", new_session_path %> to write a review.</p>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: [book, review], local: true, html: { class: "form-panel" } do |f| %>
+  <div class="field">
+    <%= f.label :rating %>
+    <div data-controller="rating">
+      <%= f.hidden_field :rating, value: review.rating, data: { rating_target: "input" } %>
+      <div class="star-rating" data-rating-target="stars">
+        <% (1..5).each do |star| %>
+          <span
+            class="star"
+            data-action="click->rating#set mouseover->rating#hover mouseout->rating#resetHover"
+            data-rating-value="<%= star %>"
+          >★</span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="field field--full">
+    <%= f.label :body, "Your review (optional)" %>
+    <%= f.text_area :body, rows: 6, placeholder: "What did you think?" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit review.persisted? ? "Update review" : "Post review" %>
+  </div>
+<% end %>

--- a/app/views/reviews/_review_card.html.erb
+++ b/app/views/reviews/_review_card.html.erb
@@ -1,19 +1,30 @@
 <% show_book = local_assigns.fetch(:show_book, true) %>
 <% sanitized_body = sanitize(review.body, tags: []) %>
 
-<div class="review-card" data-controller="review-modal" id="review-<%= review.id %>">
-  <!-- Header Row: Date + Delete Button -->
+<div class="review-card" id="review-<%= review.id %>">
+  <!-- Header Row: Date + Action Buttons -->
   <div class="review-header" style="display: flex; align-items: center;">
     <p class="date" style="margin: 0;"><%= review.created_at.strftime("%b %d, %Y") %></p>
     <% if review.user == current_user %>
-      <div style="margin-left: auto;" data-controller="confirm">
-        <button type="button" class="btn btn--danger btn--sm" data-action="confirm#open">Delete</button>
-        <div class="modal" data-confirm-target="modal">
-          <div class="modal-content">
-            <p>Delete this review?</p>
-            <div style="display: flex; flex-direction: row; gap: 20px">
-              <%= button_to "Delete", book_review_path(review.book, review), method: :delete, class: "btn btn--danger btn--sm" %>
-              <button type="button" class="btn btn--sm" data-action="confirm#close">Cancel</button>
+      <div style="margin-left: auto; display: flex; gap: 10px;">
+        <div data-controller="review-modal">
+          <button type="button" class="btn btn--sm" data-action="review-modal#open">Edit</button>
+          <div class="modal" data-review-modal-target="modal">
+            <div class="modal-content">
+              <button class="modal-close" data-action="review-modal#close">Close</button>
+              <%= render "reviews/form", review: review, book: review.book %>
+            </div>
+          </div>
+        </div>
+        <div data-controller="confirm">
+          <button type="button" class="btn btn--danger btn--sm" data-action="confirm#open">Delete</button>
+          <div class="modal" data-confirm-target="modal">
+            <div class="modal-content">
+              <p>Delete this review?</p>
+              <div style="display: flex; flex-direction: row; gap: 20px">
+                <%= button_to "Delete", book_review_path(review.book, review), method: :delete, class: "btn btn--danger btn--sm" %>
+                <button type="button" class="btn btn--sm" data-action="confirm#close">Cancel</button>
+              </div>
             </div>
           </div>
         </div>
@@ -32,23 +43,21 @@
   <p class="rating"><strong><%= review.rating %></strong> / 5</p>
 
   <!-- Review Body with Inline "See more" -->
-  <p class="review-body">
-    <% if sanitized_body.length > 150 %>
-      <%= truncate(sanitized_body, length: 150, omission: '...') %>
-      <a href="#" class="see-more-link" data-action="review-modal#open">See more</a>
-    <% else %>
-      <%= sanitized_body %>
-    <% end %>
-  </p>
-
-  <!-- Modal for Full Review -->
   <% if sanitized_body.length > 150 %>
-    <div class="modal" data-review-modal-target="modal">
-      <div class="modal-content">
-        <button class="modal-close" data-action="review-modal#close">Close</button>
-        <p><%= simple_format(sanitized_body) %></p>
+    <div data-controller="review-modal">
+      <p class="review-body">
+        <%= truncate(sanitized_body, length: 150, omission: '...') %>
+        <a href="#" class="see-more-link" data-action="review-modal#open">See more</a>
+      </p>
+      <div class="modal" data-review-modal-target="modal">
+        <div class="modal-content">
+          <button class="modal-close" data-action="review-modal#close">Close</button>
+          <p><%= simple_format(sanitized_body) %></p>
+        </div>
       </div>
     </div>
+  <% else %>
+    <p class="review-body"><%= sanitized_body %></p>
   <% end %>
 
   <!-- Like Section -->


### PR DESCRIPTION
## Summary
- allow editing a review from each review card via a modal form
- reuse review form partial for posting and editing
- show message instead of review form when a user has already reviewed a book

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*


------
https://chatgpt.com/codex/tasks/task_e_689c8b3711cc83219381a50bdec8df47