### PR TITLE
Add paginated favorite sections and lazy loading

### DIFF
--- a/app/javascript/controllers/favorite_scroll_controller.js
+++ b/app/javascript/controllers/favorite_scroll_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["loader"]
+  static values = { categoryId: Number, offset: Number, limit: { type: Number, default: 20 } }
+
+  connect() {
+    this.loading = false
+    this.done = false
+    this.onScroll = this.onScroll.bind(this)
+    this.element.addEventListener("scroll", this.onScroll)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("scroll", this.onScroll)
+  }
+
+  onScroll() {
+    if (this.done || this.loading) return
+    const nearEnd = this.element.scrollLeft + this.element.clientWidth >= this.element.scrollWidth - 50
+    if (nearEnd) {
+      this.loadMore()
+    }
+  }
+
+  loadMore() {
+    this.loading = true
+    if (this.hasLoaderTarget) {
+      this.loaderTarget.classList.remove("hidden")
+    }
+    const url = `/books/more_favorites?category_id=${this.categoryIdValue}&offset=${this.offsetValue}&limit=${this.limitValue}`
+    fetch(url, { headers: { Accept: "text/html" } })
+      .then((r) => r.text())
+      .then((html) => {
+        if (html.trim() === "") {
+          this.done = true
+          return
+        }
+        this.element.insertAdjacentHTML("beforeend", html)
+        this.offsetValue += this.limitValue
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (this.hasLoaderTarget) {
+          this.loaderTarget.classList.add("hidden")
+        }
+        this.loading = false
+      })
+  }
+}
+

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -60,10 +60,15 @@
 
   <% @personalized_sections.each do |section| %>
     <h3><%= section[:category].name %></h3>
-    <div class="book-grid">
+    <div class="book-row" 
+         data-controller="favorite-scroll"
+         data-favorite-scroll-category-id-value="<%= section[:category].id %>"
+         data-favorite-scroll-offset-value="<%= section[:books].size %>"
+         data-favorite-scroll-limit-value="20">
       <% section[:books].each do |book| %>
         <%= render "book_card", book: book %>
       <% end %>
+      <div class="loader hidden" data-favorite-scroll-target="loader">Loading...</div>
     </div>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
       post   :add_to_library                            # login required
       delete :remove_from_library                       # login required
     end
+    collection do
+      get :more_favorites
+    end
   end
 
   get "my/reviews", to: "reviews#index", as: :my_reviews


### PR DESCRIPTION
## Summary
- Limit category book fetches to 20 and add `more_favorites` endpoint for pagination
- Introduce Stimulus controller to load additional favorite books as user scrolls
- Render favorite categories as horizontal rows that dynamically append new pages

## Testing
- `bin/rails test` *(fails: Could not find required gems)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_689ca41f1a9083219d10ab24f94a4a4e