### PR TITLE
Add favorites pagination page and fix favorites layout

### DIFF
--- a/app/assets/stylesheets/forgotten.css
+++ b/app/assets/stylesheets/forgotten.css
@@ -216,10 +216,33 @@ input::placeholder {
   gap: 14px;
   margin-top: 10px;
   overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 10px;
 }
 
 .book-row > * {
   flex: 0 0 auto;
+}
+
+.favorite-category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.favorite-category-header h3 {
+  margin: 0;
+}
+
+.see-more-btn {
+  margin-left: 10px;
+}
+
+@media (max-width: 600px) {
+  .see-more-btn {
+    display: none;
+  }
 }
 
 .book-card {

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -59,7 +59,7 @@ class BooksController < ApplicationController
     end
   end
 
-  before_action :require_login, only: [ :add_to_library, :remove_from_library, :more_favorites ]
+  before_action :require_login, only: [ :add_to_library, :remove_from_library, :more_favorites, :favorites ]
 
   def add_to_library
     book = Book.find(params[:id])
@@ -83,5 +83,22 @@ class BooksController < ApplicationController
     limit = params.fetch(:limit, 20).to_i
     books = category.books.offset(offset).limit(limit)
     render partial: "book_card", collection: books, as: :book
+  end
+
+  def favorites
+    @category = current_user.categories.find_by(id: params[:category_id])
+    return redirect_to books_path, alert: "Category not found" unless @category
+
+    per_page = 30
+    @page = params[:page].to_i
+    offset = @page * per_page
+    scope = @category.books
+    @books_count = scope.count
+    @books = scope.offset(offset).limit(per_page + 1)
+    @has_next = @books.size > per_page
+    @books = @books.first(per_page)
+    @total_pages = (@books_count.to_f / per_page).ceil
+    @results_start = offset + 1
+    @results_end = [ offset + @books.size, @books_count ].min
   end
 end

--- a/app/views/books/favorites.html.erb
+++ b/app/views/books/favorites.html.erb
@@ -1,0 +1,42 @@
+<h1><%= @category.name %></h1>
+
+<div class="book-grid">
+  <% @books.each do |book| %>
+    <%= render "book_card", book: book %>
+  <% end %>
+</div>
+
+<div style="display: flex; flex-direction: column; justify-content: center; align-items: center">
+  <p class="muted">Results: <%= @results_start %> - <%= @results_end %> of <%= @books_count %></p>
+  <div class="review-pagination top-bar">
+    <% if @page.positive? %>
+      <%= link_to "Back", favorites_books_path(category_id: @category.id, page: @page - 1), class: "btn" %>
+    <% else %>
+      <span class="btn disabled">Back</span>
+    <% end %>
+    <% first_pages = [3, @total_pages].min %>
+    <% (0...first_pages).each do |p| %>
+      <% if p == @page %>
+        <span class="btn"><%= p + 1 %></span>
+      <% else %>
+        <%= link_to p + 1, favorites_books_path(category_id: @category.id, page: p), class: "btn" %>
+      <% end %>
+    <% end %>
+    <% if @total_pages > 3 %>
+      <% if @total_pages > 4 %>
+        <span class="btn">&hellip;</span>
+      <% end %>
+      <% last_page = @total_pages - 1 %>
+      <% if last_page == @page %>
+        <span class="btn"><%= @total_pages %></span>
+      <% else %>
+        <%= link_to @total_pages, favorites_books_path(category_id: @category.id, page: last_page), class: "btn" %>
+      <% end %>
+    <% end %>
+    <% if @has_next %>
+      <%= link_to "Next", favorites_books_path(category_id: @category.id, page: @page + 1), class: "btn" %>
+    <% else %>
+      <span class="btn disabled">Next</span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -59,8 +59,11 @@
   <h2>Your Favorite Categories</h2>
 
   <% @personalized_sections.each do |section| %>
-    <h3><%= section[:category].name %></h3>
-    <div class="book-row" 
+    <div class="favorite-category-header">
+      <h3><%= section[:category].name %></h3>
+      <%= link_to "See more", favorites_books_path(category_id: section[:category].id), class: "btn see-more-btn" %>
+    </div>
+    <div class="book-row"
          data-controller="favorite-scroll"
          data-favorite-scroll-category-id-value="<%= section[:category].id %>"
          data-favorite-scroll-offset-value="<%= section[:books].size %>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       delete :remove_from_library                       # login required
     end
     collection do
+      get :favorites
       get :more_favorites
     end
   end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -18,5 +18,22 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".book-card", 5
   end
+
+  test "paginates favorite category results" do
+    user = User.create!(name: "Test", email: "test@example.com", password: "secret")
+    user.categories << @category
+    35.times do |i|
+      Book.create!(title: "Fav #{i}", author: "Auth #{i}", category: @category)
+    end
+
+    post session_path, params: { email: user.email, password: "secret" }
+    get favorites_books_path(category_id: @category.id)
+    assert_response :success
+    assert_select ".book-card", 30
+
+    get favorites_books_path(category_id: @category.id, page: 1)
+    assert_response :success
+    assert_select ".book-card", 5
+  end
 end
 


### PR DESCRIPTION
## Summary
- prevent horizontal scrollbar from overlapping favorite book cards
- add desktop-only "See more" buttons for favorite categories
- provide paginated favorites view listing category books vertically

## Testing
- `bundle exec rake test` *(fails: Could not find required gems)*

------
https://chatgpt.com/codex/tasks/task_e_689ca89fddbc83219d933867e027dee1