### PR TITLE
Toggle comment replies and reply forms via Stimulus

### DIFF
--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form", "replies", "repliesLink"]
+
+  connect() {
+    if (this.hasRepliesLinkTarget) {
+      this.repliesLinkTarget.dataset.originalText = this.repliesLinkTarget.textContent
+    }
+  }
+
+  toggleForm(event) {
+    event.preventDefault()
+    this.formTarget.classList.toggle("hidden")
+  }
+
+  toggleReplies(event) {
+    event.preventDefault()
+    this.repliesTarget.classList.toggle("hidden")
+    if (this.hasRepliesLinkTarget) {
+      const expanded = !this.repliesTarget.classList.contains("hidden")
+      this.repliesLinkTarget.textContent = expanded ? "Hide replies" : this.repliesLinkTarget.dataset.originalText
+    }
+  }
+}
+

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,17 +1,27 @@
-<div class="comment" id="comment-<%= comment.id %>">
+<div class="comment" id="comment-<%= comment.id %>" data-controller="comment">
   <p><strong><%= comment.user.name %>:</strong> <%= sanitize(comment.body, tags: []) %></p>
   <% if logged_in? && comment.user == current_user %>
     <%= button_to 'Delete', review_comment_path(comment.review, comment), method: :delete, class: 'btn btn--sm' %>
   <% end %>
 
-  <% comment.replies.order(created_at: :asc).each do |reply| %>
-    <div class="comment-reply" style="margin-left: 20px;">
-      <%= render "comments/comment", comment: reply %>
+  <% if comment.replies.any? %>
+    <p>
+      <a href="#" data-action="comment#toggleReplies" data-comment-target="repliesLink">View <%= pluralize(comment.replies.count, 'reply') %> replies</a>
+    </p>
+    <div data-comment-target="replies" class="hidden">
+      <% comment.replies.order(created_at: :asc).each do |reply| %>
+        <div class="comment-reply" style="margin-left: 20px;">
+          <%= render "comments/comment", comment: reply %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 
   <% if logged_in? %>
-    <div class="reply-form" style="margin-left: 20px;">
+    <p>
+      <a href="#" data-action="comment#toggleForm">Reply</a>
+    </p>
+    <div class="reply-form hidden" data-comment-target="form" style="margin-left: 20px;">
       <%= render "comments/form", review: comment.review, parent: comment %>
     </div>
   <% end %>


### PR DESCRIPTION
## Summary
- hide replies and reply forms by default and reveal them via new links
- add Stimulus controller to toggle reply form and reply visibility on comments

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689d9a9a479c83219eca3044bf8f750c