### PR TITLE
Refine comment replies and nesting

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,11 +6,16 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true
 
+  before_validation :limit_depth
   before_save :strip_html_from_body
 
   private
 
   def strip_html_from_body
     self.body = ActionController::Base.helpers.sanitize(body, tags: [], attributes: [])
+  end
+
+  def limit_depth
+    self.parent = parent.parent if parent&.parent
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,9 +1,6 @@
 <div class="comment" id="comment-<%= comment.id %>" data-controller="comment">
   
   <p class="comment__header"><strong><%= comment.user.name %>:</strong> <%= sanitize(comment.body, tags: []) %></p>
-  <% if logged_in? && comment.user == current_user %>
-    <%= button_to 'Delete', review_comment_path(comment.review, comment), method: :delete, class: 'btn btn--sm' %>
-  <% end %>
 
   <% if comment.replies.any? %>
     <p>
@@ -21,9 +18,12 @@
   <% if logged_in? %>
     <p>
       <a href="#" data-action="comment#toggleForm">Reply</a>
+      <% if comment.user == current_user %>
+        | <%= link_to 'Delete', review_comment_path(comment.review, comment), data: { turbo_method: :delete } %>
+      <% end %>
     </p>
     <div class="comment-reply reply-form hidden" data-comment-target="form">
-      <%= render "comments/form", review: comment.review, parent: comment %>
+      <%= render "comments/form", review: comment.review, parent: comment, reply_to: comment %>
     </div>
   <% end %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,8 +1,9 @@
 <% parent = local_assigns[:parent] %>
+<% reply_to = local_assigns[:reply_to] %>
 <%= form_with model: [review, Comment.new], local: true do |f| %>
   <%= f.hidden_field :parent_id, value: parent.id if parent %>
   <div class="field field--full">
-    <%= f.text_area :body, rows: 2, placeholder: "Add a comment" %>
+    <%= f.text_area :body, rows: 2, placeholder: "Add a comment", value: (reply_to ? "@#{reply_to.user.name} " : nil) %>
   </div>
   <div class="actions">
     <%= f.submit "Post", class: "btn btn--sm" %>

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -18,4 +18,13 @@ class CommentTest < ActiveSupport::TestCase
     assert_equal parent, reply.parent
     assert_includes parent.replies, reply
   end
+
+  test "replying to a reply stays at second level" do
+    parent = comments(:one)
+    reply = Comment.create!(user: users(:two), review: reviews(:one), body: "Reply", parent: parent)
+    second_reply = Comment.create!(user: users(:one), review: reviews(:one), body: "Another", parent: reply)
+    assert_equal parent, second_reply.parent
+    assert_includes parent.replies, second_reply
+    assert_not_includes reply.replies, second_reply
+  end
 end


### PR DESCRIPTION
## Summary
- display delete comment control as a link beside the reply link
- prefill reply form with `@username` and cap comment depth at two levels
- test: ensure replying to a reply stays on same level

## Testing
- `bin/rails test` *(fails: Could not find rails-8.0.2 ... Bundler::GemNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_689dc135f9d8832195fa0808af3f32f2