### PR TITLE
Add GraphQL types for core models

### DIFF
--- a/app/graphql/library_backend_schema.rb
+++ b/app/graphql/library_backend_schema.rb
@@ -18,9 +18,18 @@ class LibraryBackendSchema < GraphQL::Schema
 
   # Union and Interface Resolution
   def self.resolve_type(abstract_type, obj, ctx)
-    # TODO: Implement this method
-    # to return the correct GraphQL object type for `obj`
-    raise(GraphQL::RequiredImplementationMissingError)
+    case obj
+    when Book
+      Types::BookType
+    when Review
+      Types::ReviewType
+    when User
+      Types::UserType
+    when Category
+      Types::CategoryType
+    else
+      raise(GraphQL::RequiredImplementationMissingError, "Unexpected object: #{obj}")
+    end
   end
 
   # Limit the size of incoming queries:

--- a/app/graphql/types/book_type.rb
+++ b/app/graphql/types/book_type.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Types
+  class BookType < Types::BaseObject
+    implements Types::NodeType
+
+    field :title, String, null: false
+    field :author, String, null: false
+    field :average_rating, Float, null: true
+    field :reviews, [Types::ReviewType], null: false
+    field :category, Types::CategoryType, null: false
+    field :owners, [Types::UserType], null: false
+
+    def reviews
+      object.reviews
+    end
+
+    def category
+      object.category
+    end
+
+    def owners
+      object.owners
+    end
+
+    def average_rating
+      object.average_rating
+    end
+  end
+end

--- a/app/graphql/types/category_type.rb
+++ b/app/graphql/types/category_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class CategoryType < Types::BaseObject
+    implements Types::NodeType
+
+    field :name, String, null: false
+    field :books, [Types::BookType], null: false
+    field :users, [Types::UserType], null: false
+
+    def books
+      object.books
+    end
+
+    def users
+      object.users
+    end
+  end
+end

--- a/app/graphql/types/review_type.rb
+++ b/app/graphql/types/review_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  class ReviewType < Types::BaseObject
+    implements Types::NodeType
+
+    field :rating, Integer, null: false
+    field :body, String, null: true
+    field :user, Types::UserType, null: false
+    field :book, Types::BookType, null: false
+
+    def user
+      object.user
+    end
+
+    def book
+      object.book
+    end
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::BaseObject
+    implements Types::NodeType
+
+    field :name, String, null: false
+    field :email, String, null: false
+    field :books, [Types::BookType], null: false
+    field :reviews, [Types::ReviewType], null: false
+    field :categories, [Types::CategoryType], null: false
+
+    def books
+      object.books
+    end
+
+    def reviews
+      object.reviews
+    end
+
+    def categories
+      object.categories
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add BookType, ReviewType, UserType, and CategoryType GraphQL objects
- wire schema resolve_type to return correct GraphQL types

## Testing
- `bundle exec rake test` *(fails: Could not find rails-8.0.2 et al., Bundler::GemNotFound)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c2280023688321b97eadc5655a0789