### PR TITLE
Add GraphQL queries and mutations

### DIFF
--- a/app/graphql/library_backend_schema.rb
+++ b/app/graphql/library_backend_schema.rb
@@ -23,6 +23,10 @@ class LibraryBackendSchema < GraphQL::Schema
       Types::BookType
     when Review
       Types::ReviewType
+    when Comment
+      Types::CommentType
+    when LibraryEntry
+      Types::LibraryEntryType
     when User
       Types::UserType
     when Category

--- a/app/graphql/mutations/create_comment.rb
+++ b/app/graphql/mutations/create_comment.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateComment < BaseMutation
+    argument :review_id, ID, required: true
+    argument :body, String, required: true
+    argument :parent_id, ID, required: false
+
+    field :comment, Types::CommentType, null: false
+
+    def resolve(review_id:, body:, parent_id: nil)
+      comment = Comment.create!(review_id: review_id, body: body, parent_id: parent_id, user: context[:current_user])
+      { comment: comment }
+    end
+  end
+end

--- a/app/graphql/mutations/create_library_entry.rb
+++ b/app/graphql/mutations/create_library_entry.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateLibraryEntry < BaseMutation
+    argument :book_id, ID, required: true
+    argument :status, String, required: false
+    argument :date_added, GraphQL::Types::ISO8601Date, required: false
+
+    field :library_entry, Types::LibraryEntryType, null: false
+
+    def resolve(book_id:, status: nil, date_added: nil)
+      entry = LibraryEntry.create!(book_id: book_id, status: status, date_added: date_added, user: context[:current_user])
+      { library_entry: entry }
+    end
+  end
+end

--- a/app/graphql/mutations/create_review.rb
+++ b/app/graphql/mutations/create_review.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateReview < BaseMutation
+    argument :book_id, ID, required: true
+    argument :rating, Integer, required: true
+    argument :body, String, required: false
+
+    field :review, Types::ReviewType, null: false
+
+    def resolve(book_id:, rating:, body: nil)
+      review = Review.create!(book_id: book_id, rating: rating, body: body, user: context[:current_user])
+      { review: review }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_comment.rb
+++ b/app/graphql/mutations/delete_comment.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Mutations
+  class DeleteComment < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+
+    def resolve(id:)
+      comment = Comment.find(id)
+      success = comment.destroy.destroyed?
+      { success: success }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_library_entry.rb
+++ b/app/graphql/mutations/delete_library_entry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Mutations
+  class DeleteLibraryEntry < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+
+    def resolve(id:)
+      entry = LibraryEntry.find(id)
+      success = entry.destroy.destroyed?
+      { success: success }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_review.rb
+++ b/app/graphql/mutations/delete_review.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Mutations
+  class DeleteReview < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+
+    def resolve(id:)
+      review = Review.find(id)
+      success = review.destroy.destroyed?
+      { success: success }
+    end
+  end
+end

--- a/app/graphql/mutations/update_comment.rb
+++ b/app/graphql/mutations/update_comment.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateComment < BaseMutation
+    argument :id, ID, required: true
+    argument :body, String, required: false
+
+    field :comment, Types::CommentType, null: false
+
+    def resolve(id:, body: nil)
+      comment = Comment.find(id)
+      comment.update!(body: body) if body
+      { comment: comment }
+    end
+  end
+end

--- a/app/graphql/mutations/update_library_entry.rb
+++ b/app/graphql/mutations/update_library_entry.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateLibraryEntry < BaseMutation
+    argument :id, ID, required: true
+    argument :status, String, required: false
+    argument :date_added, GraphQL::Types::ISO8601Date, required: false
+
+    field :library_entry, Types::LibraryEntryType, null: false
+
+    def resolve(id:, **attributes)
+      entry = LibraryEntry.find(id)
+      entry.update!(attributes.compact)
+      { library_entry: entry }
+    end
+  end
+end

--- a/app/graphql/mutations/update_review.rb
+++ b/app/graphql/mutations/update_review.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateReview < BaseMutation
+    argument :id, ID, required: true
+    argument :rating, Integer, required: false
+    argument :body, String, required: false
+
+    field :review, Types::ReviewType, null: false
+
+    def resolve(id:, **attributes)
+      review = Review.find(id)
+      review.update!(attributes.compact)
+      { review: review }
+    end
+  end
+end

--- a/app/graphql/types/comment_type.rb
+++ b/app/graphql/types/comment_type.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Types
+  class CommentType < Types::BaseObject
+    implements Types::NodeType
+
+    field :body, String, null: false
+    field :user, Types::UserType, null: false
+    field :review, Types::ReviewType, null: false
+    field :parent, Types::CommentType, null: true
+    field :replies, [Types::CommentType], null: false
+
+    def user
+      object.user
+    end
+
+    def review
+      object.review
+    end
+
+    def parent
+      object.parent
+    end
+
+    def replies
+      object.replies
+    end
+  end
+end

--- a/app/graphql/types/library_entry_type.rb
+++ b/app/graphql/types/library_entry_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  class LibraryEntryType < Types::BaseObject
+    implements Types::NodeType
+
+    field :status, String, null: false
+    field :date_added, GraphQL::Types::ISO8601Date, null: false
+    field :user, Types::UserType, null: false
+    field :book, Types::BookType, null: false
+
+    def user
+      object.user
+    end
+
+    def book
+      object.book
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,11 +2,16 @@
 
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :create_review, mutation: Mutations::CreateReview
+    field :update_review, mutation: Mutations::UpdateReview
+    field :delete_review, mutation: Mutations::DeleteReview
+
+    field :create_comment, mutation: Mutations::CreateComment
+    field :update_comment, mutation: Mutations::UpdateComment
+    field :delete_comment, mutation: Mutations::DeleteComment
+
+    field :create_library_entry, mutation: Mutations::CreateLibraryEntry
+    field :update_library_entry, mutation: Mutations::UpdateLibraryEntry
+    field :delete_library_entry, mutation: Mutations::DeleteLibraryEntry
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -18,14 +18,30 @@ module Types
       ids.map { |id| context.schema.object_from_id(id, context) }
     end
 
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    field :books, [Types::BookType], null: false
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    def books
+      Book.all
+    end
+
+    field :book, Types::BookType, null: true do
+      argument :id, ID, required: true
+    end
+
+    def book(id:)
+      Book.find_by(id: id)
+    end
+
+    field :reviews, [Types::ReviewType], null: false
+
+    def reviews
+      Review.all
+    end
+
+    field :current_user, Types::UserType, null: true
+
+    def current_user
+      context[:current_user]
     end
   end
 end


### PR DESCRIPTION
## Summary
- expose books, book, reviews, and currentUser query fields
- add mutations to create, update, and delete reviews, comments, and library entries
- extend schema with comment and library entry types

## Testing
- `bundle exec rake test` *(fails: Could not find required gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c22976ee7483219d9c3fe63c72ea32