### PR TITLE
Add GraphQL authorization context and guards

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -11,8 +11,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: current_user
     }
     result = LibraryBackendSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result

--- a/app/graphql/mutations/create_comment.rb
+++ b/app/graphql/mutations/create_comment.rb
@@ -9,7 +9,9 @@ module Mutations
     field :comment, Types::CommentType, null: false
 
     def resolve(review_id:, body:, parent_id: nil)
-      comment = Comment.create!(review_id: review_id, body: body, parent_id: parent_id, user: context[:current_user])
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
+      comment = Comment.create!(review_id: review_id, body: body, parent_id: parent_id, user: user)
       { comment: comment }
     end
   end

--- a/app/graphql/mutations/create_library_entry.rb
+++ b/app/graphql/mutations/create_library_entry.rb
@@ -9,7 +9,9 @@ module Mutations
     field :library_entry, Types::LibraryEntryType, null: false
 
     def resolve(book_id:, status: nil, date_added: nil)
-      entry = LibraryEntry.create!(book_id: book_id, status: status, date_added: date_added, user: context[:current_user])
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
+      entry = LibraryEntry.create!(book_id: book_id, status: status, date_added: date_added, user: user)
       { library_entry: entry }
     end
   end

--- a/app/graphql/mutations/create_review.rb
+++ b/app/graphql/mutations/create_review.rb
@@ -9,7 +9,9 @@ module Mutations
     field :review, Types::ReviewType, null: false
 
     def resolve(book_id:, rating:, body: nil)
-      review = Review.create!(book_id: book_id, rating: rating, body: body, user: context[:current_user])
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
+      review = Review.create!(book_id: book_id, rating: rating, body: body, user: user)
       { review: review }
     end
   end

--- a/app/graphql/mutations/delete_comment.rb
+++ b/app/graphql/mutations/delete_comment.rb
@@ -7,7 +7,10 @@ module Mutations
     field :success, Boolean, null: false
 
     def resolve(id:)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       comment = Comment.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless comment.user == user
       success = comment.destroy.destroyed?
       { success: success }
     end

--- a/app/graphql/mutations/delete_library_entry.rb
+++ b/app/graphql/mutations/delete_library_entry.rb
@@ -7,7 +7,10 @@ module Mutations
     field :success, Boolean, null: false
 
     def resolve(id:)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       entry = LibraryEntry.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless entry.user == user
       success = entry.destroy.destroyed?
       { success: success }
     end

--- a/app/graphql/mutations/delete_review.rb
+++ b/app/graphql/mutations/delete_review.rb
@@ -7,7 +7,10 @@ module Mutations
     field :success, Boolean, null: false
 
     def resolve(id:)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       review = Review.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless review.user == user
       success = review.destroy.destroyed?
       { success: success }
     end

--- a/app/graphql/mutations/update_comment.rb
+++ b/app/graphql/mutations/update_comment.rb
@@ -8,7 +8,10 @@ module Mutations
     field :comment, Types::CommentType, null: false
 
     def resolve(id:, body: nil)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       comment = Comment.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless comment.user == user
       comment.update!(body: body) if body
       { comment: comment }
     end

--- a/app/graphql/mutations/update_library_entry.rb
+++ b/app/graphql/mutations/update_library_entry.rb
@@ -9,7 +9,10 @@ module Mutations
     field :library_entry, Types::LibraryEntryType, null: false
 
     def resolve(id:, **attributes)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       entry = LibraryEntry.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless entry.user == user
       entry.update!(attributes.compact)
       { library_entry: entry }
     end

--- a/app/graphql/mutations/update_review.rb
+++ b/app/graphql/mutations/update_review.rb
@@ -9,7 +9,10 @@ module Mutations
     field :review, Types::ReviewType, null: false
 
     def resolve(id:, **attributes)
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Authentication required" unless user
       review = Review.find(id)
+      raise GraphQL::ExecutionError, "Not authorized" unless review.user == user
       review.update!(attributes.compact)
       { review: review }
     end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -6,6 +6,12 @@ module Types
 
     field :name, String, null: false
     field :email, String, null: false
+
+    def email
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Not authorized" unless user == object
+      object.email
+    end
     field :books, [Types::BookType], null: false
     field :reviews, [Types::ReviewType], null: false
     field :categories, [Types::CategoryType], null: false


### PR DESCRIPTION
## Summary
- pass current_user into GraphQL context
- enforce authentication and ownership in GraphQL mutations
- restrict email field exposure to authenticated owner

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rails test` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68c22c60521483218fdf3af579fa3d0a